### PR TITLE
Handle Redis outages during login and restore Tailwind styles

### DIFF
--- a/apps/api/videochat_api/api/endpoints/auth.py
+++ b/apps/api/videochat_api/api/endpoints/auth.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import logging
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response, status
+from redis.exceptions import RedisError
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,9 +27,11 @@ from videochat_api.schemas import (
     RegisterRequest,
     UserResponse,
 )
-from videochat_api.services.rate_limiter import RedisRateLimiter
+from videochat_api.services.rate_limiter import RateLimitResult, RateLimiter
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+logger = logging.getLogger(__name__)
 
 
 @router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
@@ -69,10 +73,22 @@ async def login_user(
     response: Response,
     payload: LoginRequest,
     db: AsyncSession = Depends(get_session_dependency),
-    rate_limiter: RedisRateLimiter = Depends(get_rate_limiter),
+    rate_limiter: RateLimiter = Depends(get_rate_limiter),
 ) -> LoginResponse:
     client_host = request.client.host if request.client else "unknown"
-    rate_limit = await rate_limiter.check(client_host)
+    try:
+        rate_limit = await rate_limiter.check(client_host)
+    except RedisError:
+        logger.warning(
+            "Не удалось проверить лимит для %s: Redis недоступен, пропускаем ограничение",
+            client_host,
+            exc_info=True,
+        )
+        rate_limit = RateLimitResult(
+            allowed=True,
+            remaining=getattr(rate_limiter, "limit", 0),
+            retry_after=0,
+        )
     if not rate_limit.allowed:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -93,7 +109,14 @@ async def login_user(
     if user.is_blocked:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User is blocked")
 
-    await rate_limiter.reset(client_host)
+    try:
+        await rate_limiter.reset(client_host)
+    except RedisError:
+        logger.warning(
+            "Не удалось сбросить лимит для %s: Redis недоступен, пропускаем сброс",
+            client_host,
+            exc_info=True,
+        )
 
     device_payload = payload.device
     device_kind = DeviceKind(device_payload.kind) if device_payload else DeviceKind.WEB

--- a/apps/api/videochat_api/dependencies.py
+++ b/apps/api/videochat_api/dependencies.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
+import logging
 
 from fastapi import Depends, HTTPException, Request, status
 from redis.asyncio import Redis
@@ -11,20 +12,28 @@ from videochat_api.auth.session import session_manager
 from videochat_api.config import settings
 from videochat_api.db.session import get_db_session
 from videochat_api.models import AuthSession, User
-from videochat_api.services.rate_limiter import RedisRateLimiter
+from videochat_api.services.rate_limiter import NullRateLimiter, RateLimiter, RedisRateLimiter
 
 
-async def get_redis(request: Request) -> Redis:
-    redis: Redis = request.app.state.redis
+logger = logging.getLogger(__name__)
+
+
+async def get_redis(request: Request) -> Redis | None:
+    redis: Redis | None = getattr(request.app.state, "redis", None)
     return redis
 
 
-async def get_rate_limiter(redis: Redis = Depends(get_redis)) -> RedisRateLimiter:
+async def get_rate_limiter(redis: Redis | None = Depends(get_redis)) -> RateLimiter:
+    limit = settings.login_rate_limit_attempts
+    window = settings.login_rate_limit_window_seconds
+    if redis is None:
+        logger.warning("Redis недоступен, rate limiter переходит в разрешающий режим")
+        return NullRateLimiter(limit=limit)
     return RedisRateLimiter(
         redis=redis,
         namespace="login",
-        limit=settings.login_rate_limit_attempts,
-        window_seconds=settings.login_rate_limit_window_seconds,
+        limit=limit,
+        window_seconds=window,
     )
 
 

--- a/apps/api/videochat_api/services/rate_limiter.py
+++ b/apps/api/videochat_api/services/rate_limiter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Protocol
 
 from redis.asyncio import Redis
 
@@ -14,6 +15,14 @@ class RateLimitResult:
     allowed: bool
     remaining: int
     retry_after: int
+
+
+class RateLimiter(Protocol):
+    limit: int
+
+    async def check(self, identifier: str) -> RateLimitResult: ...
+
+    async def reset(self, identifier: str) -> None: ...
 
 
 class RedisRateLimiter:
@@ -37,3 +46,14 @@ class RedisRateLimiter:
     async def reset(self, identifier: str) -> None:
         redis_key = _key(self.namespace, identifier)
         await self.redis.delete(redis_key)
+
+
+class NullRateLimiter:
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+
+    async def check(self, identifier: str) -> RateLimitResult:
+        return RateLimitResult(allowed=True, remaining=self.limit, retry_after=0)
+
+    async def reset(self, identifier: str) -> None:
+        return None

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@source "./**/*.{ts,tsx}";
+@source "../../packages/ui/src/**/*.{ts,tsx}";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {


### PR DESCRIPTION
## Summary
- add Tailwind `@source` globs so the web app and shared UI components receive styling
- introduce a permissive rate limiter fallback when Redis is unavailable and log the degraded mode
- guard login rate limit checks and resets against Redis outages to avoid spurious authentication errors

## Testing
- pnpm --filter @video-chat/api test *(fails: No projects matched the filters)*

------
https://chatgpt.com/codex/tasks/task_e_68e658255e548320a373b44bd352e164