### PR TITLE
Fix enum serialization for auth sessions and devices

### DIFF
--- a/apps/api/videochat_api/models/device.py
+++ b/apps/api/videochat_api/models/device.py
@@ -21,7 +21,15 @@ class Device(Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False)
     identifier: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
-    kind: Mapped[DeviceKind] = mapped_column(Enum(DeviceKind, name="device_kind"), nullable=False)
+    kind: Mapped[DeviceKind] = mapped_column(
+        Enum(
+            DeviceKind,
+            name="device_kind",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+            validate_strings=True,
+        ),
+        nullable=False,
+    )
     display_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     user_agent: Mapped[str | None] = mapped_column(String(255), nullable=True)
     refresh_token_hash: Mapped[str | None] = mapped_column(String(128), nullable=True, index=True)

--- a/apps/api/videochat_api/models/session.py
+++ b/apps/api/videochat_api/models/session.py
@@ -24,7 +24,15 @@ class AuthSession(Base):
     device_id: Mapped[int | None] = mapped_column(
         ForeignKey("devices.id", ondelete="CASCADE"), nullable=True, index=True
     )
-    kind: Mapped[SessionKind] = mapped_column(Enum(SessionKind, name="session_kind"), nullable=False)
+    kind: Mapped[SessionKind] = mapped_column(
+        Enum(
+            SessionKind,
+            name="session_kind",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+            validate_strings=True,
+        ),
+        nullable=False,
+    )
     session_token_hash: Mapped[str | None] = mapped_column(String(128), nullable=True, unique=True)
     csrf_token: Mapped[str | None] = mapped_column(String(128), nullable=True)
     refresh_token_hash: Mapped[str | None] = mapped_column(String(128), nullable=True, unique=True)

--- a/apps/web/lib/server/set-cookie.ts
+++ b/apps/web/lib/server/set-cookie.ts
@@ -51,6 +51,7 @@ export async function applyResponseCookies(response: Response, store?: CookieSto
 
     if (isAuthDebugEnabled()) {
       const { name, value: _value, ...attributes } = parsed
+      void _value
       appliedCookies.push({ name, attributes })
     }
   }
@@ -90,9 +91,11 @@ function collectSetCookieHeaders(headers: Headers): string[] {
     }
   }
 
-  const getSetCookie = (headers as unknown as { getSetCookie?: () => string[] | undefined }).getSetCookie
+  const getSetCookie = (headers as unknown as {
+    getSetCookie?: () => string[] | undefined
+  }).getSetCookie
   if (typeof getSetCookie === "function") {
-    for (const header of getSetCookie() ?? []) {
+    for (const header of getSetCookie.call(headers) ?? []) {
       pushValue(header)
     }
   }


### PR DESCRIPTION
## Summary
- ensure AuthSession.kind stores lowercase enum values by configuring SQLAlchemy Enum
- align Device.kind column serialization with database enum definitions

## Testing
- `cd apps/api && pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68e6de3a006083209fd28dfa750117aa