### PR TITLE
Keep presence TTL refreshed for active sockets

### DIFF
--- a/apps/api/videochat_api/services/presence.py
+++ b/apps/api/videochat_api/services/presence.py
@@ -29,6 +29,10 @@ class PresenceService:
     def _key(user_id: int) -> str:
         return f"presence:user:{user_id}"
 
+    @property
+    def ttl(self) -> int:
+        return self._ttl
+
     async def set_status(self, user_id: int, status: PresenceStatus) -> PresenceState:
         updated_at = datetime.now(timezone.utc)
         payload = {"status": status, "updatedAt": updated_at.isoformat()}
@@ -40,6 +44,21 @@ class PresenceService:
 
     async def set_offline(self, user_id: int) -> PresenceState:
         return await self.set_status(user_id, "offline")
+
+    async def refresh_online(self, user_id: int) -> bool:
+        """Extend TTL for an online user without changing the payload.
+
+        Returns ``True`` when the TTL was refreshed successfully and ``False`` when
+        no presence information existed (in which case the caller may need to
+        re-publish the online status).
+        """
+
+        refreshed = await self._redis.expire(self._key(user_id), self._ttl)
+        if refreshed:
+            return True
+
+        await self.set_online(user_id)
+        return False
 
     async def get_status(self, user_id: int) -> PresenceState | None:
         raw = await self._redis.get(self._key(user_id))

--- a/apps/api/videochat_api/websocket/server.py
+++ b/apps/api/videochat_api/websocket/server.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
@@ -24,6 +26,9 @@ sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
 _fastapi_app: FastAPI | None = None
 _active_user_sids: dict[int, set[str]] = defaultdict(set)
 _sid_to_user: dict[str, int] = {}
+_presence_refresh_tasks: dict[int, asyncio.Task[None]] = {}
+
+_REFRESH_MARGIN_SECONDS = 5
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,6 +132,35 @@ def _get_presence_service(scope: dict[str, Any]) -> PresenceService | None:
     return getattr(app.state, "presence_service", None) if app is not None else None
 
 
+def _schedule_presence_refresh(user_id: int, presence_service: PresenceService) -> None:
+    if user_id in _presence_refresh_tasks:
+        return
+
+    async def _keepalive() -> None:
+        interval = max(1, presence_service.ttl - _REFRESH_MARGIN_SECONDS)
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                if not _active_user_sids.get(user_id):
+                    break
+                try:
+                    refreshed = await presence_service.refresh_online(user_id)
+                    if not refreshed and not _active_user_sids.get(user_id):
+                        break
+                except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+                    raise
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception(
+                        "Failed to refresh presence", extra={"user_id": user_id}
+                    )
+        except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+            raise
+        finally:
+            _presence_refresh_tasks.pop(user_id, None)
+
+    _presence_refresh_tasks[user_id] = asyncio.create_task(_keepalive())
+
+
 @sio.event
 async def connect(sid: str, environ: dict[str, Any], auth: dict[str, Any] | None) -> None:
     scope: dict[str, Any] = environ.get("asgi.scope", {})
@@ -153,6 +187,7 @@ async def connect(sid: str, environ: dict[str, Any], auth: dict[str, Any] | None
         await _broadcast_presence(update, friend_ids)
 
     if presence_service:
+        _schedule_presence_refresh(socket_user.id, presence_service)
         await _send_snapshot(sid, presence_service, friend_ids)
 
     logger.info(
@@ -179,6 +214,11 @@ async def disconnect(sid: str) -> None:
     connections.discard(sid)
     if not connections:
         _active_user_sids.pop(user_id, None)
+        task = _presence_refresh_tasks.get(user_id)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
         if presence_service:
             update = await presence_service.set_offline(user_id)
             await _broadcast_presence(update, friend_ids)


### PR DESCRIPTION
## Summary
- expose PresenceService TTL and add a refresh helper to extend online status without rewriting metadata
- track per-user keepalive tasks in the websocket server to refresh presence TTL while sockets remain connected
- cancel keepalive tasks when the last connection closes before broadcasting an offline update

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eaae445a008320be2223ee3f766826