### PR TITLE
Fix GET /auth/me admin alias handling

### DIFF
--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -29,7 +29,10 @@ async def test_web_login_cookie_flow(
 
     me_response = await client.get("/auth/me")
     assert me_response.status_code == 200
-    assert me_response.json()["username"] == "webuser"
+    me_payload = me_response.json()
+    assert me_payload["username"] == "webuser"
+    assert me_payload["isAdmin"] is False
+    assert "is_admin" not in me_payload
 
     logout_response = await client.post(
         "/auth/logout",
@@ -74,7 +77,10 @@ async def test_refresh_rotation_and_logout(client, user_factory) -> None:
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert me_response.status_code == 200
-    assert me_response.json()["username"] == "desktop"
+    me_payload = me_response.json()
+    assert me_payload["username"] == "desktop"
+    assert me_payload["isAdmin"] is False
+    assert "is_admin" not in me_payload
 
     refresh_payload = {"refresh_token": refresh_token, "device_id": device_id}
     refresh_response = await client.post("/auth/refresh", json=refresh_payload)
@@ -93,6 +99,10 @@ async def test_refresh_rotation_and_logout(client, user_factory) -> None:
         headers={"Authorization": f"Bearer {new_access}"},
     )
     assert me_with_new_access.status_code == 200
+    me_new_payload = me_with_new_access.json()
+    assert me_new_payload["username"] == "desktop"
+    assert me_new_payload["isAdmin"] is False
+    assert "is_admin" not in me_new_payload
 
     logout_response = await client.post(
         "/auth/logout",

--- a/apps/api/videochat_api/schemas/auth.py
+++ b/apps/api/videochat_api/schemas/auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import AliasChoices, BaseModel, EmailStr, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, EmailStr, Field
 
 
 class RegisterRequest(BaseModel):
@@ -54,6 +54,8 @@ class LogoutRequest(BaseModel):
 
       
 class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     username: str
     email: EmailStr
@@ -62,6 +64,3 @@ class UserResponse(BaseModel):
         validation_alias=AliasChoices("is_admin", "isAdmin"),
         serialization_alias="isAdmin",
     )
-
-    class Config:
-        from_attributes = True


### PR DESCRIPTION
## Summary
- configure the `UserResponse` schema to read ORM attributes while serializing `isAdmin`
- extend authentication flow tests to assert that `/auth/me` returns the `isAdmin` flag without snake_case duplicates

## Testing
- pytest tests/test_auth.py::test_web_login_cookie_flow -q *(fails: missing httpx dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f013b1d6f083209e1e3ae85f84f30e