### PR TITLE
Add REST endpoint for room join confirmation

### DIFF
--- a/apps/api/tests/test_rooms.py
+++ b/apps/api/tests/test_rooms.py
@@ -232,6 +232,61 @@ async def test_leave_room_moves_to_ending(
 
 
 @pytest.mark.asyncio
+async def test_join_room_activates_and_is_idempotent(
+    client: AsyncClient,
+    user_factory,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    monkeypatch,
+) -> None:
+    alice = await user_factory("alice", "alice@example.com", "Password123!")
+    bob = await user_factory("bob", "bob@example.com", "Password123!")
+
+    await _create_friendship(sessionmaker, alice.id, bob.id)
+
+    await _login(client, "alice")
+    create_response = await client.post("/rooms", json={"targetUserId": str(bob.id)})
+    assert create_response.status_code == 201
+    room_id = create_response.json()["room"]["id"]
+
+    emitted: list[tuple[str, dict, str | None]] = []
+
+    async def fake_emit(event: str, payload: dict, room: str | None = None, **_: object) -> None:
+        emitted.append((event, payload, room))
+
+    monkeypatch.setattr("videochat_api.api.endpoints.rooms.sio.emit", fake_emit)
+
+    await _login(client, "bob")
+
+    join_response = await client.post(f"/rooms/{room_id}/join")
+    assert join_response.status_code == 200
+
+    join_payload = join_response.json()["room"]
+    assert join_payload["status"] == "active"
+    participant_ids = {participant["userId"] for participant in join_payload["participants"]}
+    assert participant_ids == {str(alice.id), str(bob.id)}
+
+    joined_events = [event for event in emitted if event[0] == "room:user_joined"]
+    assert joined_events, "ожидалось уведомление о присоединении"
+    assert any(
+        room == f"video-room:{room_id}" and payload["userId"] == str(bob.id)
+        for _, payload, room in joined_events
+    )
+    assert any(
+        room == f"user:{alice.id}" and payload["userId"] == str(bob.id)
+        for _, payload, room in joined_events
+    )
+
+    emitted_count = len(joined_events)
+
+    second_join = await client.post(f"/rooms/{room_id}/join")
+    assert second_join.status_code == 200
+    assert second_join.json()["room"]["status"] == "active"
+
+    joined_events_after = [event for event in emitted if event[0] == "room:user_joined"]
+    assert len(joined_events_after) == emitted_count
+
+
+@pytest.mark.asyncio
 async def test_list_rooms_requires_admin(
     client: AsyncClient,
     user_factory,

--- a/apps/api/videochat_api/api/endpoints/rooms.py
+++ b/apps/api/videochat_api/api/endpoints/rooms.py
@@ -180,3 +180,54 @@ async def leave_room(
         )
 
     return RoomStatusResponse(room=room_schema)
+
+
+@router.post("/{room_id}/join", response_model=RoomStatusResponse)
+async def join_room(
+    room_id: str,
+    db: AsyncSession = Depends(get_session_dependency),
+    redis: Redis | None = Depends(get_redis),
+    current_user: User = Depends(get_current_user),
+) -> RoomStatusResponse:
+    try:
+        room_uuid = uuid.UUID(room_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Комната не найдена") from exc
+
+    service = _build_service(db, redis)
+    try:
+        room, changed = await service.join_room(room_uuid, current_user)
+    except RoomNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except RoomForbiddenError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except RoomConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    room_schema = _model_to_schema(room)
+
+    if changed:
+        payload = {
+            "room": room_schema.model_dump(mode="json", by_alias=True),
+            "userId": str(current_user.id),
+        }
+        await sio.emit(
+            "room:user_joined",
+            payload,
+            room=f"video-room:{room_schema.id}",
+        )
+
+        recipient_ids = {
+            participant.user_id
+            for participant in room_schema.participants
+            if participant.user_id != str(current_user.id)
+        }
+
+        for recipient_id in recipient_ids:
+            await sio.emit(
+                "room:user_joined",
+                payload,
+                room=f"user:{recipient_id}",
+            )
+
+    return RoomStatusResponse(room=room_schema)


### PR DESCRIPTION
## Summary
- add a POST /rooms/{room_id}/join endpoint that allows invited participants to activate a room through HTTP and handles domain errors
- emit Socket.IO notifications to the video room and waiting participants when the join changes state
- cover the new join flow with a pytest ensuring activation and idempotency

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68f01f8cc5a88320ada9f13def581465