### PR TITLE
Fix room join enum serialization and add regression test

### DIFF
--- a/apps/api/tests/test_rooms.py
+++ b/apps/api/tests/test_rooms.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 import uuid
 
 import pytest
@@ -6,7 +7,12 @@ from httpx import AsyncClient
 from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
 
+from videochat_api.api.endpoints.rooms import _model_to_schema
 from videochat_api.models import FriendRelationship, FriendStatus as FriendModelStatus, User
+from videochat_api.schemas import (
+    RoomParticipantRole as RoomParticipantRoleSchema,
+    RoomStatus as RoomStatusSchema,
+)
 from videochat_api.services.rooms import RoomService
 
 
@@ -284,6 +290,52 @@ async def test_join_room_activates_and_is_idempotent(
 
     joined_events_after = [event for event in emitted if event[0] == "room:user_joined"]
     assert len(joined_events_after) == emitted_count
+
+
+@pytest.mark.asyncio
+async def test_model_to_schema_accepts_string_enums(
+    app: FastAPI,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    user_factory,
+) -> None:
+    alice = await user_factory("alice", "alice@example.com", "Password123!")
+    bob = await user_factory("bob", "bob@example.com", "Password123!")
+
+    await _create_friendship(sessionmaker, alice.id, bob.id)
+
+    async with sessionmaker() as session:
+        service = RoomService(session, app.state.redis)
+        initiator = await session.get(User, alice.id)
+        invitee = await session.get(User, bob.id)
+        assert initiator is not None
+        assert invitee is not None
+
+        room = await service.create_room(initiator, invitee)
+        room, _ = await service.join_room(room.id, invitee)
+
+        stringified_room = SimpleNamespace(
+            id=room.id,
+            status=room.status.value,
+            initiator_id=room.initiator_id,
+            created_at=room.created_at,
+            updated_at=room.updated_at,
+            closed_at=room.closed_at,
+            participants=[
+                SimpleNamespace(
+                    user_id=participant.user_id,
+                    role=participant.role.value,
+                    joined_at=participant.joined_at,
+                    left_at=participant.left_at,
+                )
+                for participant in room.participants
+            ],
+        )
+
+    schema = _model_to_schema(stringified_room)  # type: ignore[arg-type]
+
+    assert schema.status == RoomStatusSchema.ACTIVE
+    roles = {participant.role for participant in schema.participants}
+    assert roles == {RoomParticipantRoleSchema.INITIATOR, RoomParticipantRoleSchema.GUEST}
 
 
 @pytest.mark.asyncio

--- a/apps/api/videochat_api/api/endpoints/rooms.py
+++ b/apps/api/videochat_api/api/endpoints/rooms.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import uuid
+from enum import Enum
+from typing import Any, Type, TypeVar
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from redis.asyncio import Redis
@@ -34,12 +36,27 @@ from videochat_api.websocket.server import sio
 
 router = APIRouter(prefix="/rooms", tags=["rooms"])
 
+EnumType = TypeVar("EnumType", bound=Enum)
+
+
+def _coerce_enum(value: Any, enum_cls: Type[EnumType]) -> EnumType:
+    if isinstance(value, enum_cls):
+        return value
+    if isinstance(value, Enum):
+        value = value.value
+    if isinstance(value, str):
+        try:
+            return enum_cls(value)
+        except ValueError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"Unknown value {value!r} for {enum_cls.__name__}") from exc
+    raise TypeError(f"Unsupported enum value {value!r} for {enum_cls.__name__}")
+
 
 def _model_to_schema(room_model: RoomModel) -> RoomSchema:
     participants = [
         RoomParticipantSchema(
             user_id=str(part.user_id),
-            role=RoomParticipantRoleSchema(part.role.value),
+            role=_coerce_enum(part.role, RoomParticipantRoleSchema),
             joined_at=part.joined_at,
             left_at=part.left_at,
         )
@@ -47,7 +64,7 @@ def _model_to_schema(room_model: RoomModel) -> RoomSchema:
     ]
     return RoomSchema(
         id=str(room_model.id),
-        status=RoomStatusSchema(room_model.status.value),
+        status=_coerce_enum(room_model.status, RoomStatusSchema),
         initiator_id=str(room_model.initiator_id),
         created_at=room_model.created_at,
         updated_at=room_model.updated_at,


### PR DESCRIPTION
## Summary
- normalize room schema serialization to accept enum instances and raw strings returned from PostgreSQL
- reuse the normalization for both room statuses and participant roles when building API responses
- add a regression test covering `_model_to_schema` with string enum values to prevent 500 errors on join

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68f263a7f5548320885eba9b34b2ec98