### PR TITLE
Fix Socket.IO integration crash in FastAPI app

### DIFF
--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,28 +1,28 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import AsyncGenerator, Awaitable, Callable
 
 import pytest
-from fastapi import FastAPI
 from httpx import AsyncClient
 
 pytest_plugins = ("pytest_asyncio_plugin",)
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from videochat_api.api.endpoints import auth as auth_endpoints
-from videochat_api.api.endpoints import friends as friends_endpoints
-from videochat_api.api.endpoints import rooms as rooms_endpoints
-from videochat_api.api.endpoints import users as users_endpoints
+from fastapi import FastAPI
+
+from videochat_api.asgi import ASGIApplication, create_socketio_fastapi_app
 from videochat_api.auth.passwords import hash_password
 from videochat_api.config import settings
 from videochat_api.db.base import Base
 from videochat_api.dependencies import get_rate_limiter, get_session_dependency
+from videochat_api.main import create_fastapi_app
 from videochat_api.models import User
 from videochat_api.services import PresenceService
-from videochat_api.websocket.server import bind_fastapi_app
+from videochat_api.websocket.server import sio
 
 
 @pytest.fixture
@@ -92,29 +92,39 @@ class _FakeRedis:
 
 
 @pytest.fixture
-async def app(sessionmaker: async_sessionmaker[AsyncSession]) -> FastAPI:
-    app = FastAPI()
-    app.include_router(auth_endpoints.router)
-    app.include_router(users_endpoints.router)
-    app.include_router(friends_endpoints.router)
-    app.include_router(rooms_endpoints.router)
+async def app(sessionmaker: async_sessionmaker[AsyncSession]) -> ASGIApplication:
+    fastapi_app = create_fastapi_app()
 
     async def override_session_dependency() -> AsyncGenerator[AsyncSession, None]:
         async with sessionmaker() as session:
             yield session
 
-    app.dependency_overrides[get_session_dependency] = override_session_dependency
-    app.dependency_overrides[get_rate_limiter] = lambda: _AllowAllLimiter()
+    fastapi_app.dependency_overrides[get_session_dependency] = (
+        override_session_dependency
+    )
+    fastapi_app.dependency_overrides[get_rate_limiter] = lambda: _AllowAllLimiter()
 
     fake_redis = _FakeRedis()
-    app.state.redis = fake_redis
-    app.state.presence_service = PresenceService(fake_redis)
-    bind_fastapi_app(app)
-    return app
+    presence_service = PresenceService(fake_redis)
+    fastapi_app.state.redis = fake_redis
+    fastapi_app.state.presence_service = presence_service
+
+    @asynccontextmanager
+    async def _lifespan_override(app: FastAPI) -> AsyncGenerator[None, None]:
+        app.state.redis = fake_redis
+        app.state.presence_service = presence_service
+        try:
+            yield
+        finally:
+            await fake_redis.aclose()
+
+    fastapi_app.router.lifespan_context = _lifespan_override
+
+    return create_socketio_fastapi_app(fastapi_app, sio)
 
 
 @pytest.fixture
-async def client(app: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+async def client(app: ASGIApplication) -> AsyncGenerator[AsyncClient, None]:
     async with AsyncClient(app=app, base_url="http://testserver") as test_client:
         yield test_client
 

--- a/apps/api/tests/test_docs.py
+++ b/apps/api/tests/test_docs.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_docs_available(client) -> None:
+    response = await client.get("/docs")
+    assert response.status_code == 200
+    assert "Swagger UI" in response.text
+
+
+@pytest.mark.anyio
+async def test_openapi_available(client) -> None:
+    response = await client.get("/openapi.json")
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload.get("openapi"), str)

--- a/apps/api/videochat_api/asgi.py
+++ b/apps/api/videochat_api/asgi.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI
+from socketio import ASGIApp as SocketIOASGIApp
+from starlette.types import Receive, Scope, Send
+
+
+class SocketIOFastAPIApp:
+    """ASGI-приложение, объединяющее FastAPI и Socket.IO."""
+
+    def __init__(
+        self,
+        fastapi_app: FastAPI,
+        socketio_app: Callable[[Scope, Receive, Send], Awaitable[None]],
+        *,
+        socketio_path: str = "/socket.io",
+    ) -> None:
+        self.fastapi_app = fastapi_app
+        self._socketio_path = self._normalize_path(socketio_path)
+        self._socketio_app = SocketIOASGIApp(
+            socketio_app, socketio_path=self._socketio_path.lstrip("/")
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope_type = scope.get("type")
+
+        if scope_type == "lifespan":
+            await self.fastapi_app(scope, receive, send)
+            return
+
+        if scope_type in {"http", "websocket"} and self._is_socketio_scope(scope):
+            await self._socketio_app(scope, receive, send)
+            return
+
+        original_app = scope.get("app")
+        scope["app"] = self.fastapi_app
+        try:
+            await self.fastapi_app(scope, receive, send)
+        finally:
+            if original_app is None:
+                scope.pop("app", None)
+            else:
+                scope["app"] = original_app
+
+    def _is_socketio_scope(self, scope: Scope) -> bool:
+        path = scope.get("path") or ""
+        normalized = path.rstrip("/")
+        return normalized == self._socketio_path or normalized.startswith(
+            f"{self._socketio_path}/"
+        )
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        if not path:
+            return "/socket.io"
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return path.rstrip("/") or "/socket.io"
+
+
+ASGIApplication = Callable[[Scope, Receive, Send], Awaitable[None]]
+
+
+def create_socketio_fastapi_app(
+    fastapi_app: FastAPI,
+    socketio_app: Callable[[Scope, Receive, Send], Awaitable[None]],
+    *,
+    socketio_path: str = "/socket.io",
+) -> SocketIOFastAPIApp:
+    """Фабрика адаптера для единообразного импорта."""
+
+    return SocketIOFastAPIApp(
+        fastapi_app=fastapi_app,
+        socketio_app=socketio_app,
+        socketio_path=socketio_path,
+    )

--- a/apps/api/videochat_api/main.py
+++ b/apps/api/videochat_api/main.py
@@ -4,9 +4,9 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from redis.asyncio import from_url as redis_from_url
-from socketio import ASGIApp
 
 from videochat_api.api.routes import router as api_router
+from videochat_api.asgi import create_socketio_fastapi_app
 from videochat_api.config import settings
 from videochat_api.db.session import get_engine
 from videochat_api import models  # noqa: F401
@@ -52,7 +52,7 @@ def create_fastapi_app() -> FastAPI:
 
 fastapi_app = create_fastapi_app()
 
-app = ASGIApp(sio, other_asgi_app=fastapi_app)
+app = create_socketio_fastapi_app(fastapi_app, sio)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add a custom Socket.IO/FastAPI adapter that preserves lifespan state for regular HTTP requests
- update the FastAPI test fixture to use the production factory and adapter and add regression coverage for /docs and /openapi.json

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68f2788c1d408320939363e6a3efc82d