### PR TITLE
docs: add self prompt for room join MissingGreenlet fix

### DIFF
--- a/apps/api/prompts/self_prompt_room_join_fix_v3.md
+++ b/apps/api/prompts/self_prompt_room_join_fix_v3.md
@@ -1,0 +1,29 @@
+# Исправление ошибки join_room с MissingGreenlet
+
+## Цель
+Исправить 500 Internal Server Error при вызове `POST /rooms/{room_id}/join`, возникающий после присоединения второго участника, чтобы второй пользователь мог успешно войти в приглашённую комнату без сбоев Redis-кеша.
+
+## Контекст
+- Ручной сценарий проверки комнат описан в README (создание дружбы, создание комнаты, join со стороны приглашённого пользователя). 【F:apps/api/README.md†L88-L125】
+- `RoomService.join_room` после `flush()` обновляет статус, коммитит и синхронизирует Redis через `_persist_cache`. 【F:apps/api/videochat_api/services/rooms.py†L120-L142】
+- `_persist_cache` сериализует `created_at`, `updated_at`, `closed_at` в ISO-формат, опираясь на серверные значения из Postgres. 【F:apps/api/videochat_api/services/rooms.py†L287-L310】
+- Таймстемпы модели управляются БД (`server_default=func.now()`, `onupdate=func.now()`), а `AsyncSession` создаётся с `expire_on_commit=False`, что не отменяет частичных истечений атрибутов после `flush()`. 【F:apps/api/videochat_api/models/room.py†L33-L64】【F:apps/api/videochat_api/db/session.py†L17-L37】
+
+## Проблема
+- При добавлении гостя в комнату `room.updated_at` помечается как "expired" из-за триггера `onupdate`. Первый доступ в `_persist_cache` пытается лениво перечитать значение через `session.execute`, но SQLAlchemy запрещает implicit IO из синхронных геттеров для `AsyncSession` и выбрасывает `MissingGreenlet`. 【F:apps/api/videochat_api/services/rooms.py†L137-L140】【F:apps/api/videochat_api/services/rooms.py†L287-L300】
+- Из-за этого endpoint возвращает 500, что воспроизводится по инструкции из Swagger и подтверждается стеком трассировки, присланным пользователем.
+
+## Предлагаемое решение
+- В `_persist_cache` перед сериализацией проверить, загружены ли `created_at`, `updated_at`, `closed_at`. Если атрибут истёк (`inspect(room).attrs[field].expired`), выполнить явный `await self._db.refresh(room, attribute_names=[field])`. Это исключит неявные запросы и обеспечит свежие значения для Redis.
+- Добавить импорт `from sqlalchemy import inspect` и переиспользовать его для нормализации статуса без повторного запроса.
+- В `join_room` и `leave_room` оставить прежний порядок `flush -> persist -> commit`, так как `_persist_cache` станет безопасным.
+- Написать регрессионный тест для сервиса: принудительно истечь `updated_at` (через `await session.flush()` + `await session.expire(room, ["updated_at"])`) перед вызовом `_persist_cache`/`join_room` и убедиться, что операция завершается без исключений, а Redis получает ожидаемые ключи.
+- При необходимости расширить фейковый Redis фикстуры, чтобы удобно проверять содержимое `room:{id}` и `room:{id}:participants`.
+
+## Проверка
+- `pytest apps/api/tests/test_rooms.py` — убедиться, что новый регрессионный тест и существующие сценарии проходят.
+- Ручная последовательность из README через Swagger: создать дружбу, комнату, выполнить join приглашённым пользователем и убедиться в ответе 200/`active`.
+
+## Риски и открытые вопросы
+- Дополнительный `refresh` на каждое сохранение комнаты увеличит количество запросов к БД; нужно удостовериться, что обновление выполняется только при истёкших полях.
+- Требуется проследить, чтобы принудительное обновление не нарушало кэш участников (`room.participants`) и не приводило к конкурентным конфликтам при множественных присоединениях.


### PR DESCRIPTION
## Summary
- add a dedicated self-prompt describing the MissingGreenlet failure when joining a room
- outline the root cause in RoomService caching logic and propose a refresh-based fix with regression testing steps

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f2979d928c832099cd19ad29ab9987