### PR TITLE
Исправление обновления кэша комнаты при присоединении

### DIFF
--- a/apps/api/tests/test_rooms.py
+++ b/apps/api/tests/test_rooms.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 import uuid
@@ -21,6 +22,8 @@ from videochat_api.schemas import (
     RoomStatus as RoomStatusSchema,
 )
 from videochat_api.services.rooms import RoomService
+
+from .conftest import _FakeRedis
 
 
 async def _login(client: AsyncClient, identifier: str, password: str = "Password123!") -> None:
@@ -369,6 +372,51 @@ async def test_join_room_normalizes_string_statuses(
     assert changed is True
     assert joined_room.status == RoomStatus.ACTIVE
     assert all(isinstance(part.role, RoomParticipantRole) for part in joined_room.participants)
+
+
+@pytest.mark.asyncio
+async def test_join_room_refreshes_expired_updated_at(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    user_factory,
+) -> None:
+    alice = await user_factory("alice", "alice@example.com", "Password123!")
+    bob = await user_factory("bob", "bob@example.com", "Password123!")
+
+    await _create_friendship(sessionmaker, alice.id, bob.id)
+
+    fake_redis = _FakeRedis()
+
+    async with sessionmaker() as session:
+        service = RoomService(session, fake_redis)
+
+        initiator = await session.get(User, alice.id)
+        invitee = await session.get(User, bob.id)
+        assert initiator is not None
+        assert invitee is not None
+
+        initiator_id = initiator.id
+        invitee_id = invitee.id
+
+        room = await service.create_room(initiator, invitee)
+        room_id = room.id
+
+        await session.flush()
+        await session.expire(room, ["updated_at"])
+
+        joined_room, changed = await service.join_room(room.id, invitee)
+
+    assert changed is True
+    assert joined_room.status == RoomStatus.ACTIVE
+
+    room_cache_raw = await fake_redis.get(f"room:{room_id}")
+    assert room_cache_raw is not None
+    cached_room = json.loads(room_cache_raw)
+    assert cached_room["id"] == str(room_id)
+    assert cached_room["status"] == RoomStatus.ACTIVE.value
+    assert cached_room["updatedAt"] is not None
+
+    participants = await fake_redis.smembers(f"room:{room_id}:participants")
+    assert participants == {str(initiator_id), str(invitee_id)}
 
 
 @pytest.mark.asyncio

--- a/apps/api/videochat_api/services/rooms.py
+++ b/apps/api/videochat_api/services/rooms.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import uuid
 
 from redis.asyncio import Redis
-from sqlalchemy import Select, and_, or_, select
+from sqlalchemy import Select, and_, inspect, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 
@@ -287,6 +287,12 @@ class RoomService:
     async def _persist_cache(self, room: Room) -> None:
         if self._redis is None:
             return
+
+        state = inspect(room)
+        for field in ("created_at", "updated_at", "closed_at"):
+            attr_state = state.attrs[field]
+            if attr_state.expired:
+                await self._db.refresh(room, attribute_names=[field])
 
         self._normalize_room_enums(room)
 


### PR DESCRIPTION
## Summary
- обновить `_persist_cache`, чтобы перед сохранением кэша явно обновлять истёкшие временные метки комнаты
- добавить регрессионный тест `test_join_room_refreshes_expired_updated_at`, проверяющий успешное присоединение гостя и содержимое Redis-кэша при истечении `updated_at`

## Testing
- `pytest apps/api/tests/test_rooms.py` *(не выполняется: в тестовом окружении отсутствует зависимость httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68f299e27ba4832083082b90d3bf8894