### PR TITLE
feat: add user deletion endpoint

### DIFF
--- a/apps/api/tests/test_users.py
+++ b/apps/api/tests/test_users.py
@@ -1,5 +1,7 @@
 import pytest
 
+from videochat_api.models import User
+
 
 async def _login(client, identifier: str, password: str = "Password123!", **extra: object) -> None:
     response = await client.post("/auth/login", json={"identifier": identifier, "password": password, **extra})
@@ -89,3 +91,70 @@ async def test_list_users_with_includes(client, user_factory) -> None:
     session = target_payload["sessions"][0]
     assert session["kind"] == "desktop"
     assert session["deviceId"] is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_by_owner(client, user_factory, sessionmaker) -> None:
+    user = await user_factory("self", "self@example.com", "Password123!")
+
+    await _login(client, "self")
+
+    response = await client.delete(f"/users/{user.id}")
+    assert response.status_code == 204
+
+    me_response = await client.get("/auth/me")
+    assert me_response.status_code == 401
+
+    async with sessionmaker() as session:
+        removed_user = await session.get(User, user.id)
+        assert removed_user is None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_by_admin(client, user_factory, sessionmaker) -> None:
+    await user_factory("admin", "admin@example.com", "Password123!", is_admin=True)
+    target = await user_factory("target-delete", "target-delete@example.com", "Password123!")
+
+    await _login(client, "admin")
+
+    response = await client.delete(f"/users/{target.id}")
+    assert response.status_code == 204
+
+    async with sessionmaker() as session:
+        removed_user = await session.get(User, target.id)
+        assert removed_user is None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_forbidden_for_other_user(client, user_factory, sessionmaker) -> None:
+    user = await user_factory("owner", "owner@example.com", "Password123!")
+    target = await user_factory("foreign", "foreign@example.com", "Password123!")
+
+    await _login(client, "owner")
+
+    response = await client.delete(f"/users/{target.id}")
+    assert response.status_code == 403
+
+    async with sessionmaker() as session:
+        existing_user = await session.get(User, target.id)
+        assert existing_user is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_not_found(client, user_factory) -> None:
+    await user_factory("admin2", "admin2@example.com", "Password123!", is_admin=True)
+
+    await _login(client, "admin2")
+
+    response = await client.delete("/users/9999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_user_invalid_identifier(client, user_factory) -> None:
+    await user_factory("admin3", "admin3@example.com", "Password123!", is_admin=True)
+
+    await _login(client, "admin3")
+
+    response = await client.delete("/users/invalid")
+    assert response.status_code == 400

--- a/apps/api/videochat_api/api/endpoints/users.py
+++ b/apps/api/videochat_api/api/endpoints/users.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from videochat_api.auth.session import session_manager
 from videochat_api.dependencies import (
     get_current_admin_user,
     get_current_user,
@@ -145,3 +146,36 @@ async def search_users(
     ]
 
     return UserSearchResponse(items=items)
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user(
+    user_id: str,
+    db: AsyncSession = Depends(get_session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    try:
+        target_id = int(user_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Некорректный идентификатор пользователя",
+        )
+
+    result = await db.execute(select(User).where(User.id == target_id))
+    target = result.scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Пользователь не найден")
+
+    is_owner = current_user.id == target.id
+    if not (current_user.is_admin or is_owner):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Недостаточно прав для удаления пользователя",
+        )
+
+    await session_manager.revoke_user_sessions(db, target.id)
+    await db.delete(target)
+    await db.commit()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Summary
- add a DELETE /users/{user_id} endpoint that lets owners or admins remove accounts after revoking active sessions
- extend user API tests to cover deletion flows and error cases

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx' because dev dependencies are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ab33895483209e2adad73a821937